### PR TITLE
fix: unblock CI and crates.io logo (rust-1.95 clippy + SHA-pinned actions + absolute README URLs)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: check
 
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: stable
@@ -44,16 +44,16 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: fmt
           args: --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: clippy
           args: -- -D warnings
@@ -66,17 +66,17 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
 
       - name: Run tests
         run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A better, faster way to count guides in CRISPR screens.
 <p>
 <a href="https://fulcrumgenomics.com">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset=".github/logos/fulcrumgenomics-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset=".github/logos/fulcrumgenomics-light.svg">
-  <img alt="Fulcrum Genomics" src=".github/logos/fulcrumgenomics-light.svg" height="100">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fulcrumgenomics/guide-counter/main/.github/logos/fulcrumgenomics-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fulcrumgenomics/guide-counter/main/.github/logos/fulcrumgenomics-light.svg">
+  <img alt="Fulcrum Genomics" src="https://raw.githubusercontent.com/fulcrumgenomics/guide-counter/main/.github/logos/fulcrumgenomics-light.svg" height="100">
 </picture>
 </a>
 </p>
@@ -45,11 +45,11 @@ As an example, we ran data from the [Sanson et al][sanson-link] paper through bo
 
 The following plot shows the amount of data recovered per sample by each of three different analyses:
 
-![Read Counts from analyzing Sanson et al. data](comparison-data/read-counts.png)
+![Read Counts from analyzing Sanson et al. data](https://raw.githubusercontent.com/fulcrumgenomics/guide-counter/main/comparison-data/read-counts.png)
 
 And the following plot shows the runtime for each of the three analyses performed using a single CPU core/thread on an Intel Core i9 powered MacBook Pro laptop:
 
-![Runtimes from analyzing Sanson et al. data](comparison-data/runtimes.png)
+![Runtimes from analyzing Sanson et al. data](https://raw.githubusercontent.com/fulcrumgenomics/guide-counter/main/comparison-data/runtimes.png)
 
 ## Installation
 

--- a/src/commands/count.rs
+++ b/src/commands/count.rs
@@ -184,7 +184,7 @@ impl Count {
     /// keys for every exact guide sequence (in upper case).  If `allow_mismatch` is true,
     /// the map will also contain keys for every one-mismatch version of every guide with the
     /// exception of any sequences that match equally well to multiple guides.
-    fn build_lookup(library: &GuideLibrary, allow_mismatch: bool) -> GuideMap {
+    fn build_lookup(library: &GuideLibrary, allow_mismatch: bool) -> GuideMap<'_> {
         info!("Building lookup.");
         let mut lookup = GuideMap::default();
         let mut dupes = HashSet::new();
@@ -341,7 +341,7 @@ impl Count {
                         }
 
                         count += 1;
-                        if count % 10_000_000 == 0 {
+                        if count.is_multiple_of(10_000_000) {
                             info!("Processed {}m reads from {:?}.", count / 1_000_000, fastq_path);
                         }
 


### PR DESCRIPTION
## Why

Three independent hygiene fixes in one PR — each is small, but together they're needed before CI is green again.

## Commits

### `docs(readme): use absolute URLs for logo images`

crates.io strips relative image paths from rendered READMEs, leaving the Fulcrum Genomics logo broken at the top of the [`guide-counter` crate page](https://crates.io/crates/guide-counter). Switching to absolute `raw.githubusercontent.com` URLs renders correctly on both GitHub and crates.io.

GitHub continues to honor `<picture>` dark/light switching; crates.io ignores `<source>` and falls back to the `<img>` (light variant), which is the same behavior as before, just no longer broken.

> Note: the crate page only updates on the next published version — this PR prevents future releases from being broken, but doesn't refresh the existing crate page.

### `ci: pin actions to full-length commit SHAs`

The org-level GitHub Actions policy "all actions must be pinned to a full-length commit SHA" was rejecting CI runs at the workflow setup step. Every `uses:` line in `.github/workflows/` now uses a 40-char SHA with the original tag preserved as a trailing comment.

### `fix(clippy): address new lints from rust-1.95`

- `clippy::manual_is_multiple_of` in `src/commands/count.rs:344` — replace `count % 10_000_000 == 0` with `count.is_multiple_of(10_000_000)`.
- `clippy::mismatched_lifetime_syntaxes` in `src/commands/count.rs:187` — `build_lookup` returns `GuideMap<'_>` to make the elided lifetime visible (the returned map borrows from the input `&GuideLibrary`).

No behavioral change.

## Verification

- `cargo clippy -- -D warnings` ✓ (matching CI args)
- `cargo test` ✓ (19 tests pass)
- CI is now running on this branch with all three commits applied.